### PR TITLE
DOCS/compile-windows.md: Update MSYS2 compilation part. Now build ffmpeg-mpv.

### DIFF
--- a/DOCS/compile-windows.md
+++ b/DOCS/compile-windows.md
@@ -134,9 +134,30 @@ Installing mpv dependencies
 # Install MSYS2 build dependencies and a MinGW-w64 compiler
 pacman -S git python $MINGW_PACKAGE_PREFIX-{pkg-config,gcc}
 
-# Install the most important MinGW-w64 dependencies. libass and lcms2 are also
-# pulled in as dependencies of ffmpeg.
-pacman -S $MINGW_PACKAGE_PREFIX-{ffmpeg,libjpeg-turbo,lua51,angleproject-git}
+# Install dependencies for ffmpeg-mpv.
+pacman -S yasm diffutils make
+
+# Install the most important dependencies for mpv. Do not install ffmpeg, as
+# only ffmpeg-mpv is supported.
+pacman -S $MINGW_PACKAGE_PREFIX-{libass,lcms2,libjpeg-turbo,lua51,angleproject-git,vulkan}
+```
+
+Building ffmpeg-mpv
+-------------------
+
+Clone the latest ffmpeg-mpv from git, then auto-configure it.
+
+```bash
+git clone https://github.com/mpv-player/ffmpeg-mpv.git && cd ffmpeg-mpv
+./configure --prefix=$MSYSTEM_PREFIX
+```
+
+Compile and install ffmpeg-mpv. Libraries will be installed to ``/mingw64/lib``
+or ``/mingw32/lib``. Be careful not to install ffmpeg from MSYS2 repository
+again, or ffmpeg-mpv will get overwritten.
+
+```bash
+make -j4 && make install && cd -
 ```
 
 Building mpv


### PR DESCRIPTION
Since only `ffmpeg-mpv` is supported now, the original guide does not work any more. I updated the `Native compilation with MSYS2` part only because I have just tried that part. The `ffmpeg-mpv` build guide is now added. I also added `vulkan` as the minimal mpv building requirement.

I agree that my changes can be relicensed to LGPL 2.1 or later.
